### PR TITLE
Update Doctored.js to run again.

### DIFF
--- a/doctored/schemas/rebuild-schema-manifest.js
+++ b/doctored/schemas/rebuild-schema-manifest.js
@@ -11,7 +11,7 @@
         app_schemas_marker = /\{MANIFEST\-START\}[\s\S]*?\{MANIFEST\-END\}/g,
         app_schemas_path = path.join(path.dirname(approot), 'js', 'app-schemas.js'),
         manifest_path = path.join(approot, 'manifest.json'),
-        blacklist = [path.basename(__filename), 'manifest.json', 'options.json', 'README.txt'],
+        blacklist = [path.basename(__filename), 'manifest.json', 'options.json', 'README.md'],
         manifest = {},
         get_schema_family = function(full_path){
             var file_options = full_path.substr(0, full_path.length - path.extname(full_path).length) + '.json',

--- a/webserver.js
+++ b/webserver.js
@@ -9,7 +9,7 @@ http.createServer(function(request, response) {
   var uri      = url.parse(request.url).pathname,
       filename = path.join(process.cwd(), uri).replace(/%20/g, ' ');
 
-  path.exists(filename, function(exists) {
+  fs.exists(filename, function(exists) {
     if(!exists) {
       response.writeHead(404, {"Content-Type": "text/plain"});
       response.write("404 Not Found\n");


### PR DESCRIPTION
1. Replaces deprecates `path.exists` with `fs.exists` so you can spin-up a local server again.
2. Blacklist `README.md` instead of `README.txt` when building the schema manifest so people can once again add their own schemas.
